### PR TITLE
商品詳細ページ

### DIFF
--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -59,7 +59,7 @@
                   %td= "配送料の負担はありません"
               %tr
                 %th 発送元の地域
-                %td=@item.prefecture_id
+                %td=@item.prefecture.name
               %tr
                 %th 発送日の目安
                 %td 


### PR DESCRIPTION
＃What
商品詳細ページにて、発送元地域の情報を表示できるようにしました。

# Why
発送元地域が数字になっていた為、見やすいように変更しました。